### PR TITLE
Fix error in requirement specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         'Programming Language :: Python :: 3.4'
     ],
     install_requires=[
-        'jupyter_geppetto=0.3.4'
+        'jupyter_geppetto>=0.3.4'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
         'Programming Language :: Python :: 3.4'
     ],
     install_requires=[
-        'jupyter_geppetto>=0.3.4'
+        'jupyter_geppetto==0.3.4'
     ],
 )


### PR DESCRIPTION
When following the installation instructions for installing from source, the install.py script failed with following error: "error in neuron_ui setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'=0.3.4'"  ".

This fixes the error. Alternatively, if you intend the exact version, replace this by "==".